### PR TITLE
Fix: Viewing skills

### DIFF
--- a/includes/defines.php
+++ b/includes/defines.php
@@ -1119,6 +1119,7 @@ define('SPELL_ATTR7_CLIENT_INDICATOR',                 0x80000000); // Client in
 
 
 // (some) Skill ids
+define('TYPE_SKILL',           15);
 define('SKILL_BLACKSMITHING',  164);
 define('SKILL_LEATHERWORKING', 165);
 define('SKILL_ALCHEMY',        171);

--- a/includes/defines.php
+++ b/includes/defines.php
@@ -1119,7 +1119,6 @@ define('SPELL_ATTR7_CLIENT_INDICATOR',                 0x80000000); // Client in
 
 
 // (some) Skill ids
-define('TYPE_SKILL',           15);
 define('SKILL_BLACKSMITHING',  164);
 define('SKILL_LEATHERWORKING', 165);
 define('SKILL_ALCHEMY',        171);

--- a/pages/skill.php
+++ b/pages/skill.php
@@ -250,8 +250,8 @@ class SkillPage extends GenericPage
         if (in_array($this->cat, [-5, 6, 7, 8, 9, 11]))
         {
             $list = [];
-            if (!empty(Game::$trainerTemplates[TYPE_SKILL][$this->typeId]))
-                $list = DB::World()->selectCol('SELECT DISTINCT ID FROM npc_trainer WHERE SpellID IN (?a) AND ID < 200000', Game::$trainerTemplates[TYPE_SKILL][$this->typeId]);
+            if (!empty(Game::$trainerTemplates[Type::SKILL][$this->typeId]))
+                $list = DB::World()->selectCol('SELECT DISTINCT ID FROM npc_trainer WHERE SpellID IN (?a) AND ID < 200000', Game::$trainerTemplates[Type::SKILL][$this->typeId]);
             else
             {
                 $mask = 0;


### PR DESCRIPTION
Added TYPE_SKILL as a define to be able to view skills.

The original version doesn't seem to use TYPE_SKILL so I have no reference to go by and therefore am not sure if this is the best way to do it or even what "category" to put it under. For now I added it above the profession skills.

Please do tell me where to put it if it's wrong and obviously I'll move it to the proper "category" in that file - or even if this is the wrong way to do it and I'll scrap it.

This does work on my end, for the record.