### PR TITLE
Fix: Show sold by tab for items

### DIFF
--- a/includes/types/item.class.php
+++ b/includes/types/item.class.php
@@ -104,7 +104,7 @@ class ItemList extends BaseType
             $rawEntries = DB::World()->select('
                 SELECT   nv.item,       nv.entry,             0  AS eventId,   nv.maxcount,   nv.extendedCost,   nv.incrtime FROM            npc_vendor   nv                                                                                                  WHERE {nv.entry IN (?a) AND} nv.item IN (?a)
                 UNION
-                SELECT genv.item, c.id1 AS `entry`, ge.eventEntry AS eventId, genv.maxcount, genv.extendedCost FROM game_event_npc_vendor genv LEFT JOIN game_event ge ON genv.eventEntry = ge.eventEntry JOIN creature c ON c.guid = genv.guid WHERE {c.id1 IN (?a) AND}   genv.item IN (?a)',
+                SELECT genv.item, c.id1 AS `entry`, ge.eventEntry AS eventId, genv.maxcount, genv.extendedCost, genv.incrtime FROM game_event_npc_vendor genv LEFT JOIN game_event ge ON genv.eventEntry = ge.eventEntry JOIN creature c ON c.guid = genv.guid WHERE {c.id1 IN (?a) AND}   genv.item IN (?a)',
                 empty($filter[Type::NPC]) || !is_array($filter[Type::NPC]) ? DBSIMPLE_SKIP : $filter[Type::NPC],
                 array_keys($this->templates),
                 empty($filter[Type::NPC]) || !is_array($filter[Type::NPC]) ? DBSIMPLE_SKIP : $filter[Type::NPC],


### PR DESCRIPTION
Added the missing column for the union select. It was causing errors and is why the *sold by* tab when viewing items wasn't showing up.