### PR TITLE
fix. Correct path to logo

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-![logo](static/images/logos/home.png)
+![logo](../static/images/logos/home.png)
 
 [🇬🇧 English](README.md) | [ 🇪🇸 Spanish](README_ES.md)
 

--- a/.github/README_ES.md
+++ b/.github/README_ES.md
@@ -1,4 +1,4 @@
-![logo](static/images/logos/home.png)
+![logo](../static/images/logos/home.png)
 
 [🇬🇧 Ingles](README.md) | [🇪🇸 Español](README_ES.md)
 


### PR DESCRIPTION
When moving the README file into the .github, the path where the logo will be searched must be modified.