### PR TITLE
chore(setup): make aowow compatible with latest AC

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -129,7 +129,7 @@ When you've created your admin account you are done.
 **Q: The Page appears white, without any styles.**
 
 - A: The static content is not being displayed. You are either using SSL and AoWoW is unable to detect it or STATIC_HOST is not defined poperly. Either way this can be fixed via config `php aowow --siteconfig`
-- Probably you need to modify [13] and [18].
+- Probably you need to modify [10] and [15].
 - For example, if your project is in `htdocs/aowow/` (or `/var/www/html/aowow`), hence you visit it with `http://localhost/aowow/`, you should put:
 
 - [10] localhost/aowow

--- a/includes/smartAI.class.php
+++ b/includes/smartAI.class.php
@@ -541,7 +541,7 @@ class SmartAI
         switch ($this->itr['target']['type'])
         {
             case SAI_TARGET_CREATURE_GUID:
-                if ($id = DB::World()->selectCell('SELECT id FROM creature WHERE guid = ?d', $this->itr['target']['param'][0]))
+                if ($id = DB::World()->selectCell('SELECT id1 FROM creature WHERE guid = ?d', $this->itr['target']['param'][0]))
                     return $id;
 
                 break;
@@ -749,7 +749,7 @@ class SmartAI
                 $t['param'][10] = $getDist($t['param'][1], $t['param'][2]);
                 break;
             case SAI_TARGET_CREATURE_GUID:                  // 10
-                if ($t['param'][10] = DB::World()->selectCell('SELECT id FROM creature WHERE guid = ?d', $t['param'][0]))
+                if ($t['param'][10] = DB::World()->selectCell('SELECT id1 FROM creature WHERE guid = ?d', $t['param'][0]))
                     $this->jsGlobals[Type::NPC][] = $t['param'][10];
                 else
                     trigger_error('SmartAI::resloveTarget - creature with guid '.$t['param'][0].' not in DB');
@@ -958,7 +958,7 @@ class SmartAI
                 break;
             case SAI_EVENT_DISTANCE_CREATURE:               // 75  -  On creature guid OR any instance of creature entry is within distance.
                 if ($e['param'][0])
-                    $e['param'][10] = DB::World()->selectCell('SELECT id FROM creature WHERE guid = ?d', $e['param'][0]);
+                    $e['param'][10] = DB::World()->selectCell('SELECT id1 FROM creature WHERE guid = ?d', $e['param'][0]);
                 // do not break;
             case SAI_EVENT_DISTANCE_GAMEOBJECT:             // 76  -  On gameobject guid OR any instance of gameobject entry is within distance.
                 if ($e['param'][0] && !$e['param'][10])

--- a/setup/tools/clisetup/setup.func.php
+++ b/setup/tools/clisetup/setup.func.php
@@ -169,7 +169,7 @@ function setup() : void
         $res   = DB::Aowow()->selectCol('SELECT `key` AS ARRAY_KEY, value FROM ?_config WHERE `key` IN ("site_host", "static_host", "force_ssl")');
         $prot  = $res['force_ssl'] ? 'https://' : 'http://';
         $cases = array(
-            'site_host'   => [$prot, $res['site_host'],   '/README.md'],
+            'site_host'   => [$prot, $res['site_host'],   '/.github/README.md'],
             'static_host' => [$prot, $res['static_host'], '/css/aowow.css']
         );
 

--- a/setup/tools/fileGen.class.php
+++ b/setup/tools/fileGen.class.php
@@ -31,7 +31,7 @@ class FileGen
     );
     public static $datasets   = array(                      // name => [AowowDeps, TCDeps, info]
         'realms'        => [null, ['realmlist'],                                                                  'datasets/realms'],
-        'statistics'    => [null, ['player_levelstats', 'player_classlevelstats'],                                'datasets/statistics'],
+        'statistics'    => [null, ['player_class_stats'],                                                         'datasets/statistics'],
         'simpleImg'     => [null, null,                                                                           'static/images/wow/[icons, Interface, ]/*'],
         'complexImg'    => [null, null,                                                                           'static/images/wow/[maps, talents/backgrounds, ]/*'],
         'talentCalc'    => [null, null,                                                                           'datasets/<locale>/talents-*'],

--- a/setup/tools/filegen/statistics.func.php
+++ b/setup/tools/filegen/statistics.func.php
@@ -8,8 +8,7 @@ if (!CLI)
 
 
     /* deps:
-     * player_classlevelstats
-     * player_levelstats
+     * player_class_stats
     */
 
     // Create 'statistics'-file in datasets
@@ -133,17 +132,20 @@ if (!CLI)
 
                 $rows = DB::World()->select('
                     SELECT
-                        pls.level AS ARRAY_KEY,
-                        pls.str - ?d, pls.agi - ?d, pls.sta - ?d, pls.inte - ?d, pls.spi - ?d,
-                        pcls.basehp, IF(pcls.basemana <> 0, pcls.basemana, 100)
+                        pcs.Level AS ARRAY_KEY,
+                        0 as Strength, pcs.Agility - ?d, pcs.Stamina - ?d, pcs.Intellect - ?d, pcs.Spirit - ?d,
+                        pcs.BaseHP, IF(pcs.BaseMana <> 0, pcs.BaseMana, 100)
                     FROM
-                        player_levelstats pls
-                    JOIN
-                        player_classlevelstats pcls ON pls.level = pcls.level AND pls.class = pcls.class
+                        player_class_stats pcs
                     WHERE
-                        pls.race = ?d AND pls.class = ?d ORDER BY pls.level ASC',
-                    $offset[0], $offset[1], $offset[2], $offset[3], $offset[4],
-                    in_array($class, [3, 7, 11]) ? 6 : 1,
+                        pcs.Class = ?d ORDER BY pcs.Level ASC',
+
+                    // IF(pcs.Strength - ?d <= 0, 0, pcs.Strength - ?d),
+
+                    // WHERE pls.race = ?d AND 
+
+                    $offset[0], /* $offset[0], */ $offset[1], $offset[2], $offset[3], $offset[4],
+                    // in_array($class, [3, 7, 11]) ? 6 : 1,
                     $class
                 );
 

--- a/setup/tools/sqlgen/creature.func.php
+++ b/setup/tools/sqlgen/creature.func.php
@@ -22,7 +22,7 @@ SqlGen::register(new class extends SetupScript
                 IF(ie.entry IS NULL, 0, ?d) AS cuFlags,          -- cuFlags
                 difficulty_entry_1, difficulty_entry_2, difficulty_entry_3,
                 KillCredit1, KillCredit2,
-                modelid1, modelid2, modelid3, modelid4,
+                0 AS modelid1, 0 AS modelid2, 0 AS modelid3, 0 AS modelid4,
                 "" AS textureString,                            -- textureString
                 0 AS modelId,                                   -- modelId
                 0 AS humanoid,                                  -- uses creaturedisplayinfoextra

--- a/setup/tools/sqlgen/quests.func.php
+++ b/setup/tools/sqlgen/quests.func.php
@@ -53,7 +53,7 @@ SqlGen::register(new class extends SetupScript
                 IFNULL(qa.SourceSpellId, 0),
                 RewardXPDifficulty,                             -- QuestXP.dbc x level
                 RewardMoney,
-                RewardBonusMoney,
+                0 AS RewardBonusMoney,
                 RewardDisplaySpell,                 RewardSpell,
                 RewardHonor * 124 * RewardKillHonor,            -- alt calculation in QuestDef.cpp -> Quest::CalculateHonorGain(playerLevel)
                 IFNULL(qa.RewardMailTemplateId, 0), IFNULL(qa.RewardMailDelay, 0),

--- a/template/pages/home.tpl.php
+++ b/template/pages/home.tpl.php
@@ -85,10 +85,10 @@ endif;
             <a href="?aboutus"><?=Lang::main('aboutUs'); ?></a>|<a href="https://github.com/azerothcore/aowow" target="_blank">Github</a>|<a href="#" id="footer-links-language"><?=Lang::main('language'); ?></a>
         </div>
         <div class="footer-copy">
-            &#12484; 2023 Aowow<br />
+            &#12484; 2024 Aowow<br />
             rev. <?=AOWOW_REVISION; ?>
             <br>
-            AzerothCore rev: <a href="https://github.com/azerothcore/azerothcore-wotlk/commit/b874760efee9a1f31a121effb1a56788a7d82e34">b874760</a>
+            AzerothCore rev: <a href="https://github.com/azerothcore/azerothcore-wotlk/commit/c0b6eae0e1b4">c0b6eae0e1b4</a>
         </div>
     </div>
 


### PR DESCRIPTION
fixed AzerothCore sql table compatibility

the PRs that were a breaking change for AoWoW are:
- creature_template_model https://github.com/azerothcore/azerothcore-wotlk/pull/19068
- quest RewardBonusMoney https://github.com/azerothcore/azerothcore-wotlk/pull/18222
- player_levelstats & player_class_stats https://github.com/azerothcore/azerothcore-wotlk/pull/14383 https://github.com/azerothcore/azerothcore-wotlk/pull/17188

moreover, the path of the README.md has been changed and it affected the aowow setup (check)